### PR TITLE
Migrate from TestRestTemplate to RestTestClient

### DIFF
--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/AbstractOppgaverApiImplTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/AbstractOppgaverApiImplTest.kt
@@ -3,20 +3,18 @@ package no.nav.eux.oppgave.webapp
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.eux.oppgave.Application
-import no.nav.eux.oppgave.webapp.common.httpEntity
 import no.nav.eux.oppgave.webapp.mock.RequestBodies
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpEntity
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.jdbc.JdbcTestUtils
+import org.springframework.test.web.servlet.client.RestTestClient
 
 @SpringBootTest(
     classes = [Application::class],
@@ -25,14 +23,14 @@ import org.springframework.test.jdbc.JdbcTestUtils
 @ActiveProfiles("test")
 @EnableMockOAuth2Server
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractOppgaverApiImplTest {
 
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
@@ -49,7 +47,4 @@ abstract class AbstractOppgaverApiImplTest {
     }
 
     val String.jsonNode: JsonNode get() = ObjectMapper().readTree(this)
-
-    val <T: Any> T.httpEntity: HttpEntity<T>
-        get() = httpEntity(mockOAuth2Server)
 }

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiFeilmeldingTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiFeilmeldingTest.kt
@@ -2,22 +2,23 @@ package no.nav.eux.oppgave.webapp
 
 import io.kotest.assertions.json.shouldMatchJsonResource
 import no.nav.eux.oppgave.webapp.common.oppgaverUrl
+import no.nav.eux.oppgave.webapp.common.token
 import no.nav.eux.oppgave.webapp.dataset.oppgaverOpprettelseFeilmelding
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
 
 class OppgaverApiFeilmeldingTest : AbstractOppgaverApiImplTest() {
 
     @Test
     fun `POST oppgaver - feilmelding - 400`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelseFeilmelding.httpEntity
-            )
-        val response = createResponse.body!!
-        response shouldMatchJsonResource "/dataset/expected/oppgave-feilmelding.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(400)
+        val createResponse = restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelseFeilmelding)
+            .exchange()
+            .expectStatus().isEqualTo(400)
+            .expectBody(String::class.java)
+            .returnResult()
+        createResponse.responseBody!! shouldMatchJsonResource "/dataset/expected/oppgave-feilmelding.json"
     }
 }

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiImplTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiImplTest.kt
@@ -12,10 +12,6 @@ import no.nav.eux.oppgave.webapp.model.TestModelFerdigstillRespons
 import no.nav.eux.oppgave.webapp.model.TestModelFerdigstillingStatus.OPPGAVE_FERDIGSTILT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.patchForObject
-import org.springframework.boot.resttestclient.postForEntity
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import java.time.LocalDate
 
@@ -23,123 +19,140 @@ class OppgaverApiImplTest : AbstractOppgaverApiImplTest() {
 
     @Test
     fun `POST oppgaver - forespørsel, valid - 201`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelse.httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgave-opprett.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
     }
 
     @Test
     fun `POST oppgaver - forespørsel, duplikat journalpostId - 409`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelse.httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgave-opprett.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
 
-        val createResponseDuplicate = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelse.httpEntity
-            )
-        assertThat(createResponseDuplicate.statusCode.value()).isEqualTo(409)
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelse)
+            .exchange()
+            .expectStatus().isEqualTo(409)
     }
 
     @Test
     fun `POST oppgaver - forespørsel, valid, ikke lag nesten lik oppgave - 201`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelseIkkeLagNestenLik.httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelseIkkeLagNestenLik)
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgave-opprett-nesten-lik.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
     }
 
     @Test
     fun `POST oppgaver - forespørsel, valid, med uuid - 201`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelseMedUuid.httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelseMedUuid)
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgave-opprett.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
     }
 
     @Test
     fun `POST oppgaver - med uuid, conflict - 409`() {
-        restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelseMedUuid.httpEntity
-            )
-        val createResponse2 = restTemplate
-            .postForEntity<String>(
-                oppgaverUrl,
-                oppgaverOpprettelseMedUuid.httpEntity
-            )
-        assertThat(createResponse2.statusCode.value()).isEqualTo(409)
-        createResponse2.body shouldMatchJsonResource "/dataset/expected/oppgave-opprett-conflict.json"
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelseMedUuid)
+            .exchange()
+            .expectStatus().isEqualTo(201)
+        val createResponse2 = restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelseMedUuid)
+            .exchange()
+            .expectStatus().isEqualTo(409)
+            .expectBody(String::class.java)
+            .returnResult()
+        createResponse2.responseBody!! shouldMatchJsonResource "/dataset/expected/oppgave-opprett-conflict.json"
     }
 
     @Test
     fun `POST oppgaver behandleSedFraJournalpostId - forespørsel, valid - 201`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                behandleSedFraJournalpostIdUrl,
-                TestModelBehandleSedFraJournalpostId("453857122").httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(behandleSedFraJournalpostIdUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(TestModelBehandleSedFraJournalpostId("453857122"))
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgave-opprett-behandleSedFraJournalpostId.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
     }
 
     @Test
     fun `POST oppgaver behandleSedFraJournalpostId - forespørsel, med aktoerId, valid - 201`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                behandleSedFraJournalpostIdUrl,
-                TestModelBehandleSedFraJournalpostIdMedAktoerId("453857122", "2280720130426").httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(behandleSedFraJournalpostIdUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(TestModelBehandleSedFraJournalpostIdMedAktoerId("453857122", "2280720130426"))
+            .exchange()
+            .expectStatus().isEqualTo(201)
         val request = requestBodies["/api/v1/oppgaver"]!!
         request shouldMatchJsonResource
                 "/dataset/expected/oppgave-opprett-behandleSedFraJournalpostIdMedPersonident.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(201)
     }
 
     @Test
     fun `POST oppgaver ferdigstill - forespørsel, valid - 200`() {
-        val createResponse = restTemplate
-            .postForEntity<TestModelFerdigstillRespons>(
-                oppgaverFerdigstillUrl,
-                oppgaverFerdigstillDataset.httpEntity
-            )
+        val createResponse = restTestClient
+            .post()
+            .uri(oppgaverFerdigstillUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverFerdigstillDataset)
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(TestModelFerdigstillRespons::class.java)
+            .returnResult()
         val request = requestBodies["/api/v1/oppgaver/190402"]!!
         request shouldMatchJsonResource "/dataset/expected/oppgaver-ferdigstill.json"
-        assertThat(createResponse.statusCode.value()).isEqualTo(200)
-        assertThat(createResponse.body!!.oppgaver[0].status)
+        assertThat(createResponse.responseBody!!.oppgaver[0].status)
             .isEqualTo(OPPGAVE_FERDIGSTILT)
-        assertThat(createResponse.body!!.oppgaver[0].beskrivelse)
+        assertThat(createResponse.responseBody!!.oppgaver[0].beskrivelse)
             .isEqualTo("Oppgave 190402 ble ferdigstilt")
     }
 
     @Test
     fun `POST oppgaver tildel enhetsnummer - forespørsel, valid - 204`() {
-        val createResponse = restTemplate
-            .postForEntity<Void>(
-                oppgaverTildelEnhetsnrUrl,
-                oppgaverTildelEnhetsnrDataset.httpEntity
-            )
+        restTestClient
+            .post()
+            .uri(oppgaverTildelEnhetsnrUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverTildelEnhetsnrDataset)
+            .exchange()
+            .expectStatus().isEqualTo(204)
         val requestBody = requestBodies["/api/v1/oppgaver/190402"]!!
         println(requestBody)
         assertThat(requestBody).contains("tilordnetRessurs")
@@ -149,28 +162,29 @@ class OppgaverApiImplTest : AbstractOppgaverApiImplTest() {
         assertThat(result["versjon"].intValue()).isEqualTo(4)
         assertThat(result["tildeltEnhetsnr"].textValue()).isEqualTo("2950")
         assertThat(result["tilordnetRessurs"].textValue()).isNull()
-        assertThat(createResponse.statusCode.value()).isEqualTo(204)
     }
 
     @Test
     fun `POST oppgaver - ikke autentisert - 401`() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        val entity = HttpEntity<String>("{}", headers)
-        val createResponse = restTemplate.postForEntity<Void>(
-            oppgaverUrl,
-            entity
-        )
-        assertThat(createResponse.statusCode.value()).isEqualTo(401)
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .exchange()
+            .expectStatus().isEqualTo(401)
     }
 
     @Test
     fun `POST oppgaver - ugyldig request - 400`() {
-        val createResponse = restTemplate.postForEntity<Void>(
-            oppgaverUrl,
-            ".".httpEntity
-        )
-        assertThat(createResponse.statusCode.value()).isEqualTo(400)
+        restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(".")
+            .exchange()
+            .expectStatus().isEqualTo(400)
     }
 
     @Test
@@ -179,14 +193,17 @@ class OppgaverApiImplTest : AbstractOppgaverApiImplTest() {
                 "?fristFom=${LocalDate.now()}fristFom&fristTom=${LocalDate.now()}fristTom&tema=BAR" +
                 "&oppgavetype=FREM&statuskategori=AAPEN" +
                 "&behandlingstema=ab0058"
-        val finnOppgaverRespons = restTemplate
-            .postForEntity<FinnOppgaverResponsOpenApiType>(
-                oppgaverFinnUrl,
-                finnOppgaverDatasetBehandlingstema.httpEntity
-            )
+        val finnOppgaverRespons = restTestClient
+            .post()
+            .uri(oppgaverFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(finnOppgaverDatasetBehandlingstema)
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(FinnOppgaverResponsOpenApiType::class.java)
+            .returnResult()
         assertThat(requestBodies.containsKey(oppgaverFinnParameterUrl))
-        assertThat(finnOppgaverRespons.statusCode.value()).isEqualTo(200)
-        assertThat(finnOppgaverRespons.body!!.oppgaver!![0].id).isEqualTo(190402)
+        assertThat(finnOppgaverRespons.responseBody!!.oppgaver!![0].id).isEqualTo(190402)
     }
 
     @Test
@@ -195,25 +212,31 @@ class OppgaverApiImplTest : AbstractOppgaverApiImplTest() {
                 "?fristFom=${LocalDate.now()}fristFom&fristTom=${LocalDate.now()}fristTom&tema=BAR" +
                 "&oppgavetype=FREM&statuskategori=AAPEN" +
                 "&behandlingstype=ae0106&limit=200&offset=10"
-        val finnOppgaverRespons = restTemplate
-            .postForEntity<FinnOppgaverResponsOpenApiType>(
-                oppgaverFinnUrl,
-                finnOppgaverDatasetBehandlingstema.httpEntity
-            )
+        val finnOppgaverRespons = restTestClient
+            .post()
+            .uri(oppgaverFinnUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(finnOppgaverDatasetBehandlingstema)
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(FinnOppgaverResponsOpenApiType::class.java)
+            .returnResult()
         assertThat(requestBodies.containsKey(oppgaverFinnParameterUrl))
-        assertThat(finnOppgaverRespons.statusCode.value()).isEqualTo(200)
-        assertThat(finnOppgaverRespons.body!!.oppgaver!!.get(0).id).isEqualTo(190402)
+        assertThat(finnOppgaverRespons.responseBody!!.oppgaver!![0].id).isEqualTo(190402)
     }
 
     @Test
     fun `PATCH oppdater oppgave - forespørsel, valid - 200`() {
-        val oppdaterOppgaveRespons = restTemplate
-            .patchForObject(
-                oppgaverUrl,
-                oppdaterOppgaveDataset.httpEntity,
-                OppgaveOpenApiType::class.java
-            )
+        val oppdaterOppgaveRespons = restTestClient
+            .patch()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppdaterOppgaveDataset)
+            .exchange()
+            .expectStatus().isEqualTo(200)
+            .expectBody(OppgaveOpenApiType::class.java)
+            .returnResult()
         assertThat(requestBodies["$oppgaverUrl/190402"]!!.jsonNode).isNotEmpty
-        assertThat(oppdaterOppgaveRespons!!.versjon).isEqualTo(4)
+        assertThat(oppdaterOppgaveRespons.responseBody!!.versjon).isEqualTo(4)
     }
 }

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiValidationTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiValidationTest.kt
@@ -2,22 +2,25 @@ package no.nav.eux.oppgave.webapp
 
 import no.nav.eux.oppgave.advice.MethodArgumentNotValidExceptionAdvice
 import no.nav.eux.oppgave.webapp.common.oppgaverUrl
+import no.nav.eux.oppgave.webapp.common.token
 import no.nav.eux.oppgave.webapp.dataset.oppgaverOpprettelse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
 
 class OppgaverApiValidationTest : AbstractOppgaverApiImplTest() {
 
     @Test
     fun `POST oppgaver - forespørsel, invalid tildeltEnhetsnr - 400`() {
-        val createResponse = restTemplate
-            .postForEntity<MethodArgumentNotValidExceptionAdvice.ApiError>(
-                oppgaverUrl,
-                oppgaverOpprettelse.copy(tildeltEnhetsnr = "12345").httpEntity
-            )
-        assertThat(createResponse.statusCode.value()).isEqualTo(400)
-        with(createResponse.body!!.errors[0]) {
+        val createResponse = restTestClient
+            .post()
+            .uri(oppgaverUrl)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(oppgaverOpprettelse.copy(tildeltEnhetsnr = "12345"))
+            .exchange()
+            .expectStatus().isEqualTo(400)
+            .expectBody(MethodArgumentNotValidExceptionAdvice.ApiError::class.java)
+            .returnResult()
+        with(createResponse.responseBody!!.errors[0]) {
             assertThat(rejectedValue).isEqualTo("12345")
             assertThat(defaultMessage).isEqualTo("size must be between 4 and 4")
         }

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/common/HttpEntity.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/common/HttpEntity.kt
@@ -3,23 +3,6 @@ package no.nav.eux.oppgave.webapp.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun <T: Any> T.httpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<T>(this, mockOAuth2Server.httpHeaders)
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Replace TestRestTemplate with Spring Framework 7 RestTestClient for test HTTP calls.