### PR TITLE
Migrate openapi-generator to 7.21.0 with Jackson 3 and Spring Boot 4

### DIFF
--- a/eux-oppgave-openapi/pom.xml
+++ b/eux-oppgave-openapi/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>6.4.0</version>
+                <version>7.21.0</version>
                 <executions>
                     <execution>
                         <id>openapi-spring</id>
@@ -60,8 +60,10 @@
                             <configOptions>
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                                 <interfaceOnly>true</interfaceOnly>
-                                <serializableModel>true</serializableModel>
-                                <useSpringBoot3>true</useSpringBoot3>
+                                <useSpringBoot4>true</useSpringBoot4>
+                                <useJackson3>true</useJackson3>
+                                <useTags>true</useTags>
+                                <enumPropertyNaming>UPPERCASE</enumPropertyNaming>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/eux-oppgave-openapi/src/main/resources/static/eux-oppgave-v1.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/eux-oppgave-v1.yaml
@@ -6,22 +6,22 @@ info:
     name: vegard.lundeberg.hillestad@nav.no
   version: v1
 servers:
-  - url: 'http://localhost:8080/api/v1'
+  - url: '/'
 tags:
-  - name: Eux Oppgave API
+  - name: Oppgaver
     description: >-
       API til bruk av EUX apper for å håndtere NAV Oppgaver
 
 paths:
-  '/oppgaver':
+  '/api/v1/oppgaver':
     $ref: 'oppgaver/operations_rot.yaml'
-  '/oppgaver/behandleSedFraJournalpostId':
+  '/api/v1/oppgaver/behandleSedFraJournalpostId':
     $ref: 'oppgaver/operations_behandleSedFraJournalpostId.yaml'
-  '/oppgaver/ferdigstill':
+  '/api/v1/oppgaver/ferdigstill':
     $ref: 'oppgaver/operations_ferdigstill.yaml'
-  '/oppgaver/tildelEnhetsnr':
+  '/api/v1/oppgaver/tildelEnhetsnr':
     $ref: 'oppgaver/operations_tildelEnhetsnr.yaml'
-  '/oppgaver/finn':
+  '/api/v1/oppgaver/finn':
     $ref: 'oppgaver/operations_finn.yaml'
-  '/oppgaver/oppgavetype':
+  '/api/v1/oppgaver/oppgavetype':
     $ref: 'oppgaver/operations_oppgavetype.yaml'

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_behandleSedFraJournalpostId.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_behandleSedFraJournalpostId.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Opprett
   description: Opprett ny NAV Oppgave basert en eksisterende oppgave knyttet til journalpostId
   operationId: behandleSedFraJournalpostId

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_ferdigstill.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_ferdigstill.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Ferdigstill
   description: Ferdigstill NAV Oppgaver
   operationId: ferdigstillOppgaver

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_finn.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_finn.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Finn
   description: Finn oppgaver basert på frister, tema og type.
   operationId: finnOppgaver

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_oppgavetype.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_oppgavetype.yaml
@@ -1,6 +1,6 @@
 patch:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Patch oppgavetype
   description: Patch oppgavetype
   operationId: patchOppgavetype

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_rot.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_rot.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Opprett
   description: Opprett ny NAV Oppgave
   operationId: opprettOppgave
@@ -30,7 +30,7 @@ post:
       $ref: '../common/responses.yaml#/500'
 patch:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Oppdater
   description: Oppdater oppgave.
   operationId: oppdaterOppgave

--- a/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_tildelEnhetsnr.yaml
+++ b/eux-oppgave-openapi/src/main/resources/static/oppgaver/operations_tildelEnhetsnr.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Eux Oppgave API
+    - Oppgaver
   summary: Tildel enhetsnummer
   description: Tildel enhetsnummer
   operationId: tildelEnhetsnummer

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/AbstractOppgaverApiImplTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/AbstractOppgaverApiImplTest.kt
@@ -1,7 +1,7 @@
 package no.nav.eux.oppgave.webapp
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
 import no.nav.eux.oppgave.Application
 import no.nav.eux.oppgave.webapp.mock.RequestBodies
 import no.nav.security.mock.oauth2.MockOAuth2Server

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiImplTest.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/OppgaverApiImplTest.kt
@@ -1,6 +1,6 @@
 package no.nav.eux.oppgave.webapp
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import io.kotest.assertions.json.shouldMatchJsonResource
 import no.nav.eux.oppgave.openapi.model.FinnOppgaverResponsOpenApiType
 import no.nav.eux.oppgave.openapi.model.OppgaveOpenApiType

--- a/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/dataset/OppgaverOppdaterOppgaveDataset.kt
+++ b/eux-oppgave-webapp/src/test/kotlin/no/nav/eux/oppgave/webapp/dataset/OppgaverOppdaterOppgaveDataset.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 val oppdaterOppgaveDataset = OppgaveOpenApiType(
     aktoerId = "2850955164683",
     aktivDato = LocalDate.parse("2024-12-01"),
-    prioritet = Prioritet.lAV,
+    prioritet = Prioritet.LAV,
     tema = "GEN",
     oppgavetype = "JFR",
     behandlingstema = "test",

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,6 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson-annotations.version>2.21</jackson-annotations.version>
-        <jackson2.version>2.21.2</jackson2.version>
-        <jackson3.version>3.1.2</jackson3.version>
         <tomcat.version>11.0.21</tomcat.version>
     </properties>
 
@@ -61,41 +58,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson-annotations.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson2.version}</version>
-        </dependency>
-    </dependencies>
 </project>


### PR DESCRIPTION
- Bump openapi-generator-maven-plugin from 6.4.0 to 7.21.0
- Enable useSpringBoot4=true and useJackson3=true; drop useSpringBoot3
- Remove serializableModel; add useTags=true and enumPropertyNaming=UPPERCASE
- Inline /api/v1/ in OpenAPI paths and set server URL to '/' to align with
  the new generator's path emission
- Rename API tag from 'Eux Oppgave API' to 'Oppgaver' so the generated
  interface keeps the OppgaverApi name
- Drop direct Jackson 2/3 dependencies and version pins from root pom;
  Jackson 3 is now provided by Spring Boot 4 BOM via parent-pom 2.0.9
- Migrate test imports to tools.jackson.databind.*
- Update Prioritet.lAV usage to Prioritet.LAV after enum naming change

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
